### PR TITLE
New launchd behavior when agent exit code is not 0

### DIFF
--- a/Library/LaunchDaemons/com.zabbix.zabbix_agentd.plist
+++ b/Library/LaunchDaemons/com.zabbix.zabbix_agentd.plist
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.zabbix.zabbix_agentd</string>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
 	<dict>
-		<key>Label</key>
-		<string>com.zabbix.zabbix_agentd</string>
-		<key>RunAtLoad</key>
-		<true/>
-		<key>UserName</key>
-		<string>zabbix</string>
-		<key>GroupName</key>
-		<string>zabbix</string>
-		<key>ProgramArguments</key>
-		<array>
-			<string>/usr/local/sbin/zabbix_agentd</string>
-			<string>-c</string>
-			<string>/usr/local/etc/zabbix/zabbix_agentd.conf</string>
-		</array>
+		<key>SuccessfulExit</key>
+		<false/>
 	</dict>
+	<key>UserName</key>
+	<string>zabbix</string>
+	<key>GroupName</key>
+	<string>zabbix</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/sbin/zabbix_agentd</string>
+		<string>-c</string>
+		<string>/usr/local/etc/zabbix/zabbix_agentd.conf</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
launchd accepts a KeepAlive dictionary with a SuccessfulExit key that,
when set to NO will automatically relaunch the deamon if it exits with
a error code different than 0.

It will also throttle relaunch attempts to one try per 10 seconds and
will log the exit code to the Console.

Reference: https://developer.apple.com/library/mac/documentation/Darwin/Reference/Manpages/man5/launchd.plist.5.html
